### PR TITLE
espacios válidos dentro del mapa, saltos de línea inválidos

### DIFF
--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cub3d.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sergio-jimenez <sergio-jimenez@student.    +#+  +:+       +#+        */
+/*   By: vjan-nie <vjan-nie@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/16 15:29:05 by vjan-nie          #+#    #+#             */
-/*   Updated: 2025/11/27 02:31:04 by sergio-jime      ###   ########.fr       */
+/*   Updated: 2025/11/28 11:11:26 by vjan-nie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,6 +75,7 @@ bool	parse_config(t_map *map, char **lines);
 bool	parse_texture(t_map *map, const char *line);
 bool	parse_color(t_map *map, const char *line);
 int		parse_rgb(const char *str);
+int		skip_config(char **lines);
 
 /* ************************************************************************** */
 /* Player */

--- a/maps/empty_line_map.cub
+++ b/maps/empty_line_map.cub
@@ -1,0 +1,15 @@
+NO ./textures/wall_north.xpm
+SO ./textures/wall_south.xpm
+WE ./textures/wall_west.xpm
+EA ./textures/wall_east.xpm
+
+C 220,30,0
+F 220,30,0
+
+111111
+1N0001
+100001
+
+10 001
+111111
+

--- a/maps/spaces.cub
+++ b/maps/spaces.cub
@@ -1,0 +1,13 @@
+NO ./textures/wall_north.xpm
+SO ./textures/wall_south.xpm
+WE ./textures/wall_west.xpm
+EA ./textures/wall_east.xpm
+
+C 220,10,1
+F 220,30,1
+
+111111
+1N00 1
+100 01
+10 001
+111111

--- a/src/parser/normalize_map.c
+++ b/src/parser/normalize_map.c
@@ -6,7 +6,7 @@
 /*   By: vjan-nie <vjan-nie@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/21 10:31:50 by vjan-nie          #+#    #+#             */
-/*   Updated: 2025/11/19 10:23:05 by vjan-nie         ###   ########.fr       */
+/*   Updated: 2025/11/28 10:32:37 by vjan-nie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,15 +61,29 @@ static char	*pad_line(char *src, int width)
 */
 void	normalize_map(t_map *map)
 {
+	int	x;
 	int	y;
 	int	max;
 
-	y = 0;
 	max = get_max_line_length(map->grid);
 	map->width = max;
+	y = 0;
 	while (map->grid[y])
 	{
 		map->grid[y] = pad_line(map->grid[y], max);
+		y++;
+	}
+	// Convertir todos los ' ' → '0'
+	y = 0;
+	while (map->grid[y])
+	{
+		x = 0;
+		while (map->grid[y][x])
+		{
+			if (map->grid[y][x] == ' ')
+				map->grid[y][x] = '0';
+			x++;
+		}
 		y++;
 	}
 }

--- a/src/parser/parse_map.c
+++ b/src/parser/parse_map.c
@@ -6,38 +6,11 @@
 /*   By: vjan-nie <vjan-nie@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/21 09:58:26 by vjan-nie          #+#    #+#             */
-/*   Updated: 2025/11/19 10:25:23 by vjan-nie         ###   ########.fr       */
+/*   Updated: 2025/11/28 11:12:29 by vjan-nie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub3d.h"
-
-/*
-** skip_config:
-** Avanza por las líneas del archivo .cub mientras sean:
-** - líneas de textura (NO, SO, WE, EA)
-** - líneas de color (F, C)
-** - líneas vacías
-**
-** Devuelve el índice de la primera línea que ya no es configuración,
-** es decir, donde comienza el mapa.
-*/
-static int	skip_config(char **lines)
-{
-	int	i;
-
-	i = 0;
-	while (lines[i])
-	{
-		if (is_texture_line(lines[i])
-			|| is_color_line(lines[i])
-			|| is_line_empty(lines[i]))
-			i++;
-		else
-			return (i);
-	}
-	return (i);
-}
 
 /*
 ** count_map_lines:

--- a/src/parser/parse_map_utils.c
+++ b/src/parser/parse_map_utils.c
@@ -3,14 +3,41 @@
 /*                                                        :::      ::::::::   */
 /*   parse_map_utils.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sergio-jimenez <sergio-jimenez@student.    +#+  +:+       +#+        */
+/*   By: vjan-nie <vjan-nie@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/18 16:55:46 by vjan-nie          #+#    #+#             */
-/*   Updated: 2025/11/27 09:17:01 by sergio-jime      ###   ########.fr       */
+/*   Updated: 2025/11/28 12:38:44 by vjan-nie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub3d.h"
+
+/*
+** skip_config:
+** Avanza por las líneas del archivo .cub mientras sean:
+** - líneas de textura (NO, SO, WE, EA)
+** - líneas de color (F, C)
+** - líneas vacías
+**
+** Devuelve el índice de la primera línea que ya no es configuración,
+** es decir, donde comienza el mapa.
+*/
+int	skip_config(char **lines)
+{
+	int	i;
+
+	i = 0;
+	while (lines[i])
+	{
+		if (is_texture_line(lines[i])
+			|| is_color_line(lines[i])
+			|| is_line_empty(lines[i]))
+			i++;
+		else
+			return (i);
+	}
+	return (i);
+}
 
 /*
 ** parse_rgb:

--- a/src/parser/validate_map.c
+++ b/src/parser/validate_map.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   validate_map.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sergio-jimenez <sergio-jimenez@student.    +#+  +:+       +#+        */
+/*   By: vjan-nie <vjan-nie@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/21 10:05:52 by vjan-nie          #+#    #+#             */
-/*   Updated: 2025/11/27 09:18:05 by sergio-jime      ###   ########.fr       */
+/*   Updated: 2025/11/28 10:47:34 by vjan-nie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,17 +17,15 @@
 ** Verifica si un carácter del mapa es válido:
 ** - '0': suelo donde el jugador puede caminar
 ** - '1': pared
-** - ' ': espacio vacío (fuera del mapa)
+** - ' ': espacio vacío
 ** - 'N', 'S', 'E', 'W': posición inicial del jugador y dirección
 */
-static bool	is_valid_char(char c)
+static bool is_valid_char(char c)
 {
-	if (c == '0' || c == '1' || c == ' ')
-		return (true);
-	if (c == 'N' || c == 'S' || c == 'E' || c == 'W')
-		return (true);
-	return (false);
+	return (c == '0' || c == '1' || c == ' '
+		 || c == 'N' || c == 'S' || c == 'E' || c == 'W');
 }
+
 
 /*
 ** validate_player_tile:
@@ -55,33 +53,32 @@ static bool	validate_player_tile(t_map *map, int *count, int y, int x)
 	return (true);
 }
 
-/*
-** is_surrounded_by_walls:
-** Verifica que una celda "caminable" (0 o jugador) esté
-** completamente rodeada por paredes o por otras celdas válidas.
-** Evita que el jugador o los espacios caminables queden expuestos.
-*/
+
 static bool	is_surrounded_by_walls(t_map *map, int y, int x)
 {
-	if (map->grid[y][x] == ' ')
-		return (false);
+	// 1. Si es pared, no hay nada que comprobar.
+	if (map->grid[y][x] == '1')
+		return true;
 
-	// Comprobamos vecinos (arriba, abajo, izquierda, derecha)
-	if (y - 1 < 0 || y + 1 >= map->height)
-		return (false);
-	if (x - 1 < 0 || x + 1 >= map->width)
-		return (false);
+	// 2. Comprobaciones de límites (no debe estar en el borde)
+	if (y == 0 || y == map->height - 1)
+		return false;
+	if (x == 0 || x == map->width - 1)
+		return false;
 
-	if (map->grid[y - 1][x] == ' ')
-		return (false);
-	if (map->grid[y + 1][x] == ' ')
-		return (false);
-	if (map->grid[y][x - 1] == ' ')
-		return (false);
-	if (map->grid[y][x + 1] == ' ')
-		return (false);
+	// 3. Vecinos: deben existir y no ser fuera del mapa
+	if (map->grid[y - 1][x] == '\0')
+		return false;
+	if (map->grid[y + 1][x] == '\0')
+		return false;
+	if (map->grid[y][x - 1] == '\0')
+		return false;
+	if (map->grid[y][x + 1] == '\0')
+		return false;
 
-	return (true);
+	// Si llegamos aquí, el tile está cerrado por algo:
+	// 1 o 0 o jugador, y es válido.
+	return true;
 }
 
 /*


### PR DESCRIPTION
Como te decía, creo que del subject se entiende que dentro del mapa los espacios son válidos como entidades propias del mapa, y que por eso los espacios valen sólo para separar info fuera del mapa. Lo que dice el subject:

º Except for the map content, each type of element can be separated by one or
more empty lines. (entiendo que el contenido del mapa no puede tener saltos de línea)

◦ Except for the map, each type of information from an element can be separated
by one or more spaces. (por ej: F 220, 30, 1) Mientras que en mapa: 100 00   01 los espacios tienen valor

◦ The map must be parsed as it looks in the file. Spaces are a valid part of the
map and are up to you to handle. You must be able to parse any kind of map,
as long as it respects the rules of the map. (lo que entiendo es que los espacios dentro del mapa no pueden ser motivo para tirarlo) Podemos usarlos como queramos, incluso dibujar. Lo que he hecho para facilitar es, a la hora de normalizar el mapa, reconvertirlos en '0', así no hay que retocar código de comprobación con el raycasting. 

[cosas1.c](https://github.com/user-attachments/files/23824370/cosas1.c)


Luego, respecto a lo de que no contenga saltos de línea el mapa, la dificultad estaba en que recogemos todo el archivo con gnl, y luego hacemos un split recortando saltos de línea para trabajar con cada línea del fichero y parsear. Entonces, los saltos de línea desaparecían. La solución efectiva que he conseguido me parece muy fea: mientras estamos leyendo el fichero, encontrar en qué punto comienza el mapa en sí, y recorrer a ver si hay saltos de línea. Lanzar error y dejar de leer. Es más eficiente creo que devolver el salto de línea a cada pedazo de split y detectar si hay un trozo de empty string que se queda con el salto de línea. Está guarrete, pero funciona:

[cosas2.c](https://github.com/user-attachments/files/23824367/cosas2.c)

Entonces, este mapa sería inválido:

NO ./textures/wall_north.xpm
SO ./textures/wall_south.xpm
WE ./textures/wall_west.xpm
EA ./textures/wall_east.xpm

C 220,30,0
F 220,30,0

111111
1N0001
100001

10 001
111111

Pero este sería válido:

NO ./textures/wall_north.xpm
SO ./textures/wall_south.xpm
WE ./textures/wall_west.xpm
EA ./textures/wall_east.xpm

C 220,10,1
F 220,30,1

111111
1N00 1
100 01
10 001
111111

He incorporado los mapas a la carpeta para seguir testeando.
